### PR TITLE
Allow parsing of tweets without media (#3)

### DIFF
--- a/lib/birdsong/tweet.rb
+++ b/lib/birdsong/tweet.rb
@@ -49,9 +49,13 @@ module Birdsong
       @language = json_tweet["lang"]
       @author_id = json_tweet["author_id"]
 
-      # A sanity check to make sure we have everything in there correctly
-      media_items = includes["media"].filter do |media_item|
-        json_tweet["attachments"]["media_keys"].include? media_item["media_key"]
+      # A sanity check to make sure we have media in there correctly
+      if includes.has_key? "media"
+        media_items = includes["media"].filter do |media_item|
+          json_tweet["attachments"]["media_keys"].include? media_item["media_key"]
+        end
+      else
+        media_items = []
       end
 
       @image_file_names = media_items.map do |media_item|

--- a/test/tweet_test.rb
+++ b/test/tweet_test.rb
@@ -34,6 +34,13 @@ class TweetTest < Minitest::Test
     end
   end
 
+  def test_that_a_tweet_can_have_no_media
+    tweet = Birdsong::Tweet.lookup("20").first
+    assert_equal tweet.id, "20"
+    assert_not_nil tweet.image_file_names
+    assert_equal 0, tweet.image_file_names.count
+  end
+
   def test_that_a_tweet_can_have_a_single_image
     tweet = Birdsong::Tweet.lookup("1407341650737762304").first
     assert_not_nil tweet.image_file_names

--- a/test/tweet_test.rb
+++ b/test/tweet_test.rb
@@ -39,6 +39,7 @@ class TweetTest < Minitest::Test
     assert_equal tweet.id, "20"
     assert_not_nil tweet.image_file_names
     assert_equal 0, tweet.image_file_names.count
+    assert_equal 0, tweet.video_file_names.count
   end
 
   def test_that_a_tweet_can_have_a_single_image


### PR DESCRIPTION
Checks tweet JSON for `media` attribute before processing it. Should fix broken tests in https://github.com/TechAndCheck/zenodotus/pull/44