### PR TITLE
Refactor video variant extraction

### DIFF
--- a/test/tweet_test.rb
+++ b/test/tweet_test.rb
@@ -54,4 +54,11 @@ class TweetTest < Minitest::Test
     assert_equal 1, tweet.video_file_names.count
     assert_equal 0, tweet.image_file_names.count
   end
+
+  def test_that_a_tweet_handles_no_variants_for_video
+    tweet = Birdsong::Tweet.lookup("1258817692448051200").first
+    assert_not_nil tweet.video_file_names
+    assert_equal 1, tweet.video_file_names.count
+    assert_equal 0, tweet.image_file_names.count
+  end
 end


### PR DESCRIPTION
This refactors the video variant extraction a bit by checking explictly
for a `bitrate` key in each one. If there isn't one, we skip it because
that means it's probably a stream not a straight video file, which we
don't want.

This also reduces an extra loop which, let's be honest, means basically
nothing, but I'm a stickler to keeping that O(n) going.

Closes #2