### PR TITLE
Recreate User URL if nil

### DIFF
--- a/lib/birdsong/user.rb
+++ b/lib/birdsong/user.rb
@@ -57,6 +57,7 @@ module Birdsong
 
       @description = json_user["description"]
       @url = json_user["url"]
+      @url = "https://www.twitter.com/#{@username}" if @url.nil?
       @followers_count = json_user["public_metrics"]["followers_count"]
       @following_count = json_user["public_metrics"]["following_count"]
       @tweet_count = json_user["public_metrics"]["tweet_count"]

--- a/test/tweet_test.rb
+++ b/test/tweet_test.rb
@@ -13,6 +13,14 @@ class TweetTest < Minitest::Test
     tweets.each { |tweet| assert_instance_of Birdsong::Tweet, tweet }
   end
 
+  def test_that_a_tweet_with_a_nil_author_url_is_recreated
+    tweets = Birdsong::Tweet.lookup("1592186302379982849")
+
+    # This tweet's author url should not be nil anymore
+    tweets.each { |tweet| assert_instance_of Birdsong::Tweet, tweet }
+    tweets.each { |tweet| assert_not_nil tweet.author.url }
+  end
+
   def test_that_a_tweet_raises_exception_with_invalid_id
     assert_raises Birdsong::InvalidIdError do
       Birdsong::Tweet.lookup("abcdef")


### PR DESCRIPTION
Due to the ongoing absolute insanity by at Twitter the Twitter API has now stopped returning URLs for User accounts. This recreates them using the username and a standard url style.

To test is just `rake test`